### PR TITLE
Bump dependencies in scod

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,20 +1,21 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"botan": "1.12.9",
+		"botan": "1.12.10",
 		"botan-math": "1.0.3",
-		"ddox": "0.16.10",
-		"diet-ng": "1.4.5",
-		"eventcore": "0.8.34",
+		"ddox": "0.16.12",
+		"diet-ng": "1.5.0",
+		"eventcore": "0.8.35",
 		"hyphenate": "1.1.1",
 		"libasync": "0.8.3",
-		"libdparse": "0.7.1",
+		"libdparse": "0.8.8",
 		"libevent": "2.0.2+2.0.16",
-		"memutils": "0.4.10",
+		"memutils": "0.4.11",
+		"mir-linux-kernel": "1.0.0",
 		"openssl": "1.1.6+1.0.1g",
-		"stdx-allocator": "2.77.1",
+		"stdx-allocator": "2.77.2",
 		"taggedalgebraic": "0.10.11",
-		"vibe-core": "1.4.0",
-		"vibe-d": "0.8.3"
+		"vibe-core": "1.4.1",
+		"vibe-d": "0.8.4"
 	}
 }


### PR DESCRIPTION
As it otherwise fails to build with 2.081.1
Maybe a good idea to add to dlang-community and the Project Tester?